### PR TITLE
Fix the resize window crash

### DIFF
--- a/BrowserClient.cpp
+++ b/BrowserClient.cpp
@@ -513,6 +513,9 @@ void BrowserClient::setSize(unsigned int width, unsigned int height)
 {
     _width = osg::maximum(0U, width);
     _height = osg::maximum(0U, height);
+
+	static unsigned char s_empty;
+	_image->setImage(0, 0, 1, 4, GL_BGRA, GL_UNSIGNED_BYTE, (unsigned char*)(&s_empty), osg::Image::NO_DELETE);
 }
 
 void BrowserClient::addExecuteCallback( ExecuteCallback* callback )


### PR DESCRIPTION
The buffer from "BrowserClient::OnPaint" comes invalid after resizing. We need to reset the image buffer.