### PR TITLE
Fix for sporadic startup crashes

### DIFF
--- a/OECefApp
+++ b/OECefApp
@@ -16,6 +16,17 @@ public:
 public:
   CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() { return _renderProcHandler; }
 
+  virtual void OnBeforeCommandLineProcessing(
+     const CefString& process_type,
+     CefRefPtr<CefCommandLine> command_line)
+  {
+      command_line->AppendSwitch( "disable-gpu" );
+      command_line->AppendSwitch( "disable-gpu-compositing" );
+      command_line->AppendSwitch( "disable-webgl" );
+      command_line->AppendSwitch( "disable-3d-apis" );
+      command_line->AppendSwitch( "enable-begin-frame-scheduling" ); 
+  }
+
 private:
   CefRefPtr<CefRenderProcessHandler> _renderProcHandler;
 


### PR DESCRIPTION
The CEF/osgEarth integration crashes sometimes after startup. Some of this Chromium flags solve this.
